### PR TITLE
Cancel default yasqe request before it starts

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -206,6 +206,8 @@ app.component("querybox", {
             persistencyExpire: 0,
         });
         this.yasqe.on("query", (_, req) => {
+            req.abort()
+
             const q = req._data.query;
             const resp = {
                 "head": {"vars": []},


### PR DESCRIPTION
I noticed dbpedia being queried in the network tab when running the demo-- it seems like that's a consequence of `yasqe`'s [default configuration](https://github.com/TriplyDB/Yasgui/blob/685d1f32a01a16eb17ce480d1766941acda9a416/packages/yasqe/src/defaults.ts#L132-L145>).

This commit aborts that request before it's able to be sent, using the [`abort` method](https://visionmedia.github.io/superagent/#aborting-requests) of the HTTP request library that `yasqe` uses.

This will stop working if `yasqe` [moves away from that library](https://github.com/TriplyDB/Yasgui/issues/150) and uses `fetch` instead.